### PR TITLE
Lower usb check frequency

### DIFF
--- a/controller/main.py
+++ b/controller/main.py
@@ -430,7 +430,7 @@ class Controller:
         self.mode = 'config'
         # no need to disable action timer, since it is a one-shot-timer
         # enable periodic prob<ing
-        pygame.time.set_timer(PROBE_EVENT, 1000)
+        pygame.time.set_timer(PROBE_EVENT, 5000)
         # enable/disable buttons
         if not self.btn_pause.toggled:
             self.activate(self.btn_start)


### PR DESCRIPTION
This means that the controller might take a few seconds to detect the lightbar but prevents the case of pygame permanently freezing due to excessive pinging.